### PR TITLE
Comment `export *` before transpiling

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,10 @@ module.exports = (source) => {
   // i.e. import GmailMessage = GoogleAppsScript.Gmail.GmailMessage;
   source = source.replace(/^.*import /mg, '// import ');
 
+  // ## Exports
+  // replace exports like `export * from 'file'`
+  source = source.replace(/(^\s*export.*from\s*['"][^'"]*['"])/mg, '// $1');
+
   // Transpile
   // https://www.typescriptlang.org/docs/handbook/compiler-options.html
   let result = ts.transpileModule(source, {

--- a/test.js
+++ b/test.js
@@ -73,6 +73,11 @@ function getCurrentMessage():GmailMessage {
   },
   testRequire: () => {
     printBeforeAndAfter(`const a = require('foo');`);
+  },
+  testExportFrom: () => {
+    printBeforeAndAfter(
+        `export * from 'file'\n` +
+        `export { foo, bar } from "file"`)
   }
 };
 


### PR DESCRIPTION
In some IDEs it is necessary to add `export * from 'file'` for autocompletion.
However, the current version of ts2gas transpiling them to invalid google script.

## Before
```javascript
v--TS--v
export * from 'file'
–––
var exports = exports || {};
var module = module || { exports: exports };
function __export(m) {
    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
}

__export(require("file"));
 ^--GS--^```
```

## After
```javascript
v--TS--v
export * from 'file'
–––
var exports = exports || {};
var module = module || { exports: exports };
// export * from 'file'
 ^--GS--^
```
See #2 