### PR TITLE
(WIP) Typescript 3.4 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/grant/ts2gas#readme",
   "dependencies": {
-    "typescript": "^3.2.2"
+    "typescript": "^3.4.0"
   },
   "devDependencies": {
     "@types/node": "^10.12.18",

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -217,13 +217,13 @@ const flipped = flip(zip);  // <T, U>(b: U, a: T) => [T, U]
 const t1 = flipped(10, 'hello');  // [string, number]
 const t2 = flipped(true, 0);  // [number, boolean]`);
   },
-//   testTypeScript_34x_improvedReadonly: () => {
-//     printBeforeAndAfter(
-// `// Improved support for read-only arrays and tuples
-// function f1(mt: [number, number], rt: readonly [number, number]) {
-//   mt[0] = 1;  // Ok
-//   rt[0] = 1;  // Error, read-only element
-// }
+  testTypeScript_34x_improvedReadonly: () => {
+    printBeforeAndAfter(
+`// Improved support for read-only arrays and tuples
+function f1(mt: [number, number], rt: readonly [number, number]) {
+  mt[0] = 1;  // Ok
+  // rt[0] = 1;  // Error, read-only element
+}
 
 // function f2(ma: string[], ra: readonly string[], mt: [string, string], rt: readonly [string, string]) {
 //   ma = ra;  // Error
@@ -240,14 +240,14 @@ const t2 = flipped(true, 0);  // [number, boolean]`);
 //   rt = mt;  // Ok
 // }
 
-// type ReadWrite<T> = { -readonly [P in keyof T] : T[P] };
+type ReadWrite<T> = { -readonly [P in keyof T] : T[P] };
 
-// type T0 = Readonly<string[]>;  // readonly string[]
-// type T1 = Readonly<[number, number]>;  // readonly [number, number]
-// type T2 = Partial<Readonly<string[]>>;  // readonly (string | undefined)[]
-// type T3 = Readonly<Partial<string[]>>;  // readonly (string | undefined)[]
-// type T4 = ReadWrite<Required<T3>>;  // string[]`);
-//   },
+type T0 = Readonly<string[]>;  // readonly string[]
+type T1 = Readonly<[number, number]>;  // readonly [number, number]
+type T2 = Partial<Readonly<string[]>>;  // readonly (string | undefined)[]
+type T3 = Readonly<Partial<string[]>>;  // readonly (string | undefined)[]
+type T4 = ReadWrite<Required<T3>>;  // string[]`);
+  },
   testTypeScript_34x_constContext: () => {
     printBeforeAndAfter(
 `// Const contexts for literal expressions

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -167,13 +167,13 @@ writeToLog(\`\${words.join(' ')}\`);`);
   // ...
 }`);
   },
-  testIssue26Export: () => {
+  testExportImportWorkaraoundPart1: () => {
     printBeforeAndAfter(
 `export const ICONS = {
   email: \`foo.png\`,
 };`);
   },
-  testIssue26Import: () => {
+  testExportImportWorkaraoundPart2: () => {
     printBeforeAndAfter(
 `import { ICONS } from './package';
 
@@ -185,7 +185,7 @@ declare namespace exports {
 exports.ICONS.email;
 `);
   },
-  testIssue26Namespaced: () => {
+  testExportImportNamespaceWorkaround: () => {
     printBeforeAndAfter(
 `namespace Package {
   export function foo() {}

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -257,7 +257,7 @@ let z = { text: "hello" } as const;  // Type { readonly text: "hello" }`);
   },
   testTypeScript_34x_globalThis: () => {
     printBeforeAndAfter(
-`// Const contexts for literal expressions
+`// \`globalThis\`
 // Add globalThis
 // @Filename: one.ts
 var a = 1;

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -225,6 +225,8 @@ function f1(mt: [number, number], rt: readonly [number, number]) {
   // rt[0] = 1;  // Error, read-only element
 }
 
+// next function statement crashes on the 'readonly string[]'
+// (bugfix is in typescript 3.5 codebase)
 // function f2(ma: string[], ra: readonly string[], mt: [string, string], rt: readonly [string, string]) {
 //   ma = ra;  // Error
 //   ma = mt;  // Ok

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -196,6 +196,76 @@ Package.foo();
 const nameIWantForMyImports = Package.foo;
 nameIWantForMyImports();`);
   },
+  testTypeScript_34x_highOrder: () => {
+    printBeforeAndAfter(
+`// Higher order function type inference
+declare function pipe<A extends any[], B, C>(ab: (...args: A) => B, bc: (b: B) => C): (...args: A) => C;
+
+declare function list<T>(a: T): T[];
+declare function box<V>(x: V): { value: V };
+
+const listBox = pipe(list, box);  // <T>(a: T) => { value: T[] }
+const boxList = pipe(box, list);  // <V>(x: V) => { value: V }[]
+
+const x1 = listBox(42);  // { value: number[] }
+const x2 = boxList('hello');  // { value: string }[]
+
+const flip = <A, B, C>(f: (a: A, b: B) => C) => (b: B, a: A) => f(a, b);
+const zip = <T, U>(x: T, y: U): [T, U] => [x, y];
+const flipped = flip(zip);  // <T, U>(b: U, a: T) => [T, U]
+
+const t1 = flipped(10, 'hello');  // [string, number]
+const t2 = flipped(true, 0);  // [number, boolean]`);
+  },
+//   testTypeScript_34x_improvedReadonly: () => {
+//     printBeforeAndAfter(
+// `// Improved support for read-only arrays and tuples
+// function f1(mt: [number, number], rt: readonly [number, number]) {
+//   mt[0] = 1;  // Ok
+//   rt[0] = 1;  // Error, read-only element
+// }
+
+// function f2(ma: string[], ra: readonly string[], mt: [string, string], rt: readonly [string, string]) {
+//   ma = ra;  // Error
+//   ma = mt;  // Ok
+//   ma = rt;  // Error
+//   ra = ma;  // Ok
+//   ra = mt;  // Ok
+//   ra = rt;  // Ok
+//   mt = ma;  // Error
+//   mt = ra;  // Error
+//   mt = rt;  // Error
+//   rt = ma;  // Error
+//   rt = ra;  // Error
+//   rt = mt;  // Ok
+// }
+
+// type ReadWrite<T> = { -readonly [P in keyof T] : T[P] };
+
+// type T0 = Readonly<string[]>;  // readonly string[]
+// type T1 = Readonly<[number, number]>;  // readonly [number, number]
+// type T2 = Partial<Readonly<string[]>>;  // readonly (string | undefined)[]
+// type T3 = Readonly<Partial<string[]>>;  // readonly (string | undefined)[]
+// type T4 = ReadWrite<Required<T3>>;  // string[]`);
+//   },
+  testTypeScript_34x_constContext: () => {
+    printBeforeAndAfter(
+`// Const contexts for literal expressions
+let x = 10 as const;  // Type 10
+let y = <const> [10, 20];  // Type readonly [10, 20]
+let z = { text: "hello" } as const;  // Type { readonly text: "hello" }`);
+  },
+  testTypeScript_34x_globalThis: () => {
+    printBeforeAndAfter(
+`// Const contexts for literal expressions
+// Add globalThis
+// @Filename: one.ts
+var a = 1;
+var b = 2;
+// @Filename: two.js
+this.c = 3;
+const total = globalThis.a + this.b + window.c + this.unknown;`);
+  },
 };
 // Run tests
 console.log('## TESTS ##');


### PR DESCRIPTION
Reference issue #35 

Typescript 3.4 introduces new features:

- Higher order function type inference
- Improved support for read-only arrays and tuples
- Const contexts for literal expressions
- `globalThis`

`package.json` needs be either `"typescript": "^3.4.0"` or `"typescript": "^3.*.*"`

in `test.ts` the following test cases (checked if passed)

- [x] `testTypeScript_34x_highOrder` Higher order function type inference
- [x] `testTypeScript_34x_improvedReadonly` Improved support for read-only arrays and tuples
- [x] `testTypeScript_34x_constContext` Const contexts for literal expressions
- [x] `testTypeScript_34x_globalThis` `globalThis`

Detailed test cases input/output:

```ts
# testTypeScript_34x_highOrder
v--TS--v
// Higher order function type inference
declare function pipe<A extends any[], B, C>(ab: (...args: A) => B, bc: (b: B) => C): (...args: A) => C;

declare function list<T>(a: T): T[];
declare function box<V>(x: V): { value: V };

const listBox = pipe(list, box);  // <T>(a: T) => { value: T[] }
const boxList = pipe(box, list);  // <V>(x: V) => { value: V }[]

const x1 = listBox(42);  // { value: number[] }
const x2 = boxList('hello');  // { value: string }[]

const flip = <A, B, C>(f: (a: A, b: B) => C) => (b: B, a: A) => f(a, b);
const zip = <T, U>(x: T, y: U): [T, U] => [x, y];
const flipped = flip(zip);  // <T, U>(b: U, a: T) => [T, U]

const t1 = flipped(10, 'hello');  // [string, number]
const t2 = flipped(true, 0);  // [number, boolean]
–––
// Compiled using ts2gas 1.6.2 (TypeScript 3.4.1)
var exports = exports || {};
var module = module || { exports: exports };
var listBox = pipe(list, box); // <T>(a: T) => { value: T[] }
var boxList = pipe(box, list); // <V>(x: V) => { value: V }[]
var x1 = listBox(42); // { value: number[] }
var x2 = boxList('hello'); // { value: string }[]
var flip = function (f) { return function (b, a) { return f(a, b); }; };
var zip = function (x, y) { return [x, y]; };
var flipped = flip(zip); // <T, U>(b: U, a: T) => [T, U]
var t1 = flipped(10, 'hello'); // [string, number]
var t2 = flipped(true, 0); // [number, boolean]
 ^--GS--^
```

- Type inference happens within the editor. Test case is to ensure output code is correct.

```ts
# testTypeScript_34x_improvedReadonly
v--TS--v
// Improved support for read-only arrays and tuples
function f1(mt: [number, number], rt: readonly [number, number]) {
  mt[0] = 1;  // Ok
  // rt[0] = 1;  // Error, read-only element
}

// function f2(ma: string[], ra: readonly string[], mt: [string, string], rt: readonly [string, string]) {
//   ma = ra;  // Error
//   ma = mt;  // Ok
//   ma = rt;  // Error
//   ra = ma;  // Ok
//   ra = mt;  // Ok
//   ra = rt;  // Ok
//   mt = ma;  // Error
//   mt = ra;  // Error
//   mt = rt;  // Error
//   rt = ma;  // Error
//   rt = ra;  // Error
//   rt = mt;  // Ok
// }

type ReadWrite<T> = { -readonly [P in keyof T] : T[P] };

type T0 = Readonly<string[]>;  // readonly string[]
type T1 = Readonly<[number, number]>;  // readonly [number, number]
type T2 = Partial<Readonly<string[]>>;  // readonly (string | undefined)[]
type T3 = Readonly<Partial<string[]>>;  // readonly (string | undefined)[]
type T4 = ReadWrite<Required<T3>>;  // string[]
–––
// Compiled using ts2gas 1.6.2 (TypeScript 3.4.1)
var exports = exports || {};
var module = module || { exports: exports };
// Improved support for read-only arrays and tuples
function f1(mt, rt) {
    mt[0] = 1; // Ok
    // rt[0] = 1;  // Error, read-only element
}
 ^--GS--^
```

- Part of test case has to be commented out in order not to crash. A Typescript has been opened

```ts
# testTypeScript_34x_constContext
v--TS--v
// Const contexts for literal expressions
let x = 10 as const;  // Type 10
let y = <const> [10, 20];  // Type readonly [10, 20]
let z = { text: "hello" } as const;  // Type { readonly text: "hello" }
–––
// Compiled using ts2gas 1.6.2 (TypeScript 3.4.1)
var exports = exports || {};
var module = module || { exports: exports };
// Const contexts for literal expressions
var x = 10; // Type 10
var y = [10, 20]; // Type readonly [10, 20]
var z = { text: "hello" }; // Type { readonly text: "hello" }
 ^--GS--^
```

- Const context happens within the editor. Test case is to ensure output code is correct.

```ts
# testTypeScript_34x_globalThis
v--TS--v
// `globalThis`
// Add globalThis
// @Filename: one.ts
var a = 1;
var b = 2;
// @Filename: two.js
this.c = 3;
const total = globalThis.a + this.b + window.c + this.unknown;
–––
// Compiled using ts2gas 1.6.2 (TypeScript 3.4.1)
var exports = exports || {};
var module = module || { exports: exports };
// `globalThis`
// Add globalThis
// @Filename: one.ts
var a = 1;
var b = 2;
// @Filename: two.js
this.c = 3;
var total = globalThis.a + this.b + window.c + this.unknown;
 ^--GS--^
```

- No error when producing output code. Adding polyfill/shim is to be done by the user
